### PR TITLE
Ensure that Sys.Break is always caught explicitly

### DIFF
--- a/tests.ml
+++ b/tests.ml
@@ -14,13 +14,6 @@ let test_snake_case =
     ; "someIdent", false
     ]
 
-let expr_to_string expr =
-  let b = Buffer.create 0 in
-  let fmt = Format.formatter_of_buffer b in
-  Printast.expression 0 fmt expr;
-  Format.pp_print_flush fmt ();
-  Buffer.contents b
-
 (** Test rate_expression. Note that the recursion is implemented by the
     ast_mapper, so subexpressions are not checked in this test.
 *)
@@ -31,7 +24,7 @@ let test_style =
   in
   let t (expr, r) =
     let name =
-      Printf.sprintf "Rate %s" (expr_to_string expr)
+      Printf.sprintf "Rate %s" (Pprintast.string_of_expression expr)
     in
     name >:: fun ctxt ->
       assert_equal

--- a/tests.ml
+++ b/tests.ml
@@ -62,6 +62,9 @@ let test_style =
     ; [%expr List.hd], Some "Use of partial function List.hd"
     ; [%expr x == Some 1], Some "Use structural comparison"
     ; [%expr let module SomeThing = M in ()], Some "Module name not in snake case: SomeThing"
+    ; [%expr try f x with e -> None], Some "Sys.Break is implicitly caught"
+    ; [%expr try f x with Sys.Break -> Some 1 | e -> None], None
+    ; [%expr try f x with Sys.Break as e -> raise e | e -> None], None
     ]
 
 let suite =

--- a/warning.ml
+++ b/warning.ml
@@ -19,6 +19,7 @@ type t =
   | Identity_sprintf_string
   | Identity_sprintf_ps
   | Module_type_name_not_uppercase of string
+  | Sys_break_implicitly_caught
 
 let to_string = function
   | List_function_on_singleton f -> Printf.sprintf "%s on singleton" f
@@ -41,3 +42,4 @@ let to_string = function
   | Identity_sprintf_string -> "Useless sprintf"
   | Identity_sprintf_ps -> "Useless sprintf"
   | Module_type_name_not_uppercase m -> Printf.sprintf "Module type name not in uppercase: %s" m
+  | Sys_break_implicitly_caught -> "Sys.Break is implicitly caught"

--- a/warning.mli
+++ b/warning.mli
@@ -19,5 +19,6 @@ type t =
   | Identity_sprintf_string
   | Identity_sprintf_ps
   | Module_type_name_not_uppercase of string
+  | Sys_break_implicitly_caught
 
 val to_string : t -> string


### PR DESCRIPTION
The `Sys.Break` exception is a bit special in that it is raised automatically by the runtime. Each function application (and maybe other kind of constructs) can raise it. So, for example it is in general an error to do:

```ocaml
try Some (f x) with
| e -> None
```

If `Sys.Break` is caught it can alter the result and the program will go on "normally". Usually it is a good idea to re-raise until a proper handler is found.

```ocaml
try Some (f x) with
| Sys.Break as e -> raise e
| e -> None
```

This new check flags `try` constructs that have both:

  - no `Sys.Break` branch
  - a wildcard branch