### PR TITLE
Only run when a compiler is running.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+- Only run when a compiler is running. Makes it possible to use directly as
+  `-package ocamllint.ppx` (#12)
+
 ## v0.2.0
 
 *2016-03-10*


### PR DESCRIPTION
If another tool (such as `ocamldep`) is running, do not run (or rather, run
`default_mapper`).

There is a small caveat in the implementation: `tool_name ()` will return a
meaningful value only from the mapper itself. So, it is not possible to call it
before the `register` call, because there it will return `"_none_"`.

Closes #12