### PR TITLE
Changes needed to compile under OCaml 4.04.0

### DIFF
--- a/4.04/compat.ml
+++ b/4.04/compat.ml
@@ -1,0 +1,17 @@
+open Parsetree
+
+let sigitem_attributes { psig_desc } =
+  match psig_desc with
+  | Psig_value vd -> [vd.pval_attributes]
+  | Psig_type (_, tdecls) -> List.map (fun tdecl -> tdecl.ptype_attributes) tdecls
+  | Psig_typext text -> [text.ptyext_attributes]
+  | Psig_exception exc -> [exc.pext_attributes]
+  | Psig_module md -> [md.pmd_attributes]
+  | Psig_recmodule mds -> List.map (fun md -> md.pmd_attributes) mds
+  | Psig_modtype pmtd -> [pmtd.pmtd_attributes]
+  | Psig_open popen -> [popen.popen_attributes]
+  | Psig_include pincl -> [pincl.pincl_attributes]
+  | Psig_class pcis
+  | Psig_class_type pcis -> List.map (fun pct -> pct.pci_attributes) pcis
+  | Psig_attribute attribute -> [[attribute]]
+  | Psig_extension (_, attributes) -> [attributes]

--- a/tests.ml
+++ b/tests.ml
@@ -74,7 +74,7 @@ let string_of_signature_item x =
   let open Format in
   ignore (flush_str_formatter ()) ;
   let f = str_formatter in
-  Pprintast.default#signature_item f x;
+  Pprintast.signature f [x];
   flush_str_formatter ()
 
 (**


### PR DESCRIPTION
Note that the addition of `4.04/compat.ml` is compatible with older versions of OCaml, but not the change to `tests.ml`.
